### PR TITLE
Update buildtools.R

### DIFF
--- a/R/buildtools.R
+++ b/R/buildtools.R
@@ -278,6 +278,18 @@ install_dependencies <- function(path = '.'){
   precache_rspm()
 
   desc <- as.data.frame(read.dcf('DESCRIPTION'))
+
+  # The following should not be needed if the remote is part of the universe
+  # However we install it anyway to avoid race conditions if the remote was just added
+  # - remotes will be overriden if are deployed to r-universe or cran 
+  remotes <- desc$Remotes
+  if(length(remotes)){
+    try({
+      remotes_repos <- split_by_comma(remotes)
+      lapply(remotes_repos, function(x){remotes::install_github(x, upgrade = FALSE)})
+    })
+  }
+
   message("Running: remotes::local_package_deps(dependencies=TRUE)")
   deps <- remotes::local_package_deps(dependencies=TRUE)
 
@@ -286,16 +298,6 @@ install_dependencies <- function(path = '.'){
 
   message("Running: utils::install.packages(deps)")
   utils::install.packages(deps)
-
-  # The following should not be needed if the remote is part of the universe
-  # However we install it anyway to avoid race conditions if the remote was just added
-  remotes <- desc$Remotes
-  if(length(remotes)){
-    try({
-      remotes_repos <- split_by_comma(remotes)
-      lapply(remotes_repos, function(x){remotes::install_github(x, upgrade = FALSE)})
-    })
-  }
 
   # Store recursive runtime and checktime dependencies
   harddeps <- remotes::local_package_deps()


### PR DESCRIPTION
Hi @jeroen,
I was thinking if you could maybe change the priority here. We experienced issue with some `insightsengineering` packages which are deployed to `r-universe`. This is what happened in our case:
- we had `Remotes:` specified in a description of our packages. For example `insightsengineering/teal*release`
- This function which I'm suggesting to change installed binaries first (devel versions from r-universe)
- and then installed dependencies once again using `remotes::install_github`. Unfortunatelly these dependencies are the latest release, so the pipeline was failing ([didn't have sufficient version of dependency](https://github.com/r-universe/pharmaverse/actions/runs/5657798730/job/15327709193))


What do you think about my proposition?